### PR TITLE
Fix version info not showing in isac status within Claude Code CLI

### DIFF
--- a/.claude/hooks/on-prompt.sh
+++ b/.claude/hooks/on-prompt.sh
@@ -29,6 +29,20 @@ if [ -z "$QUERY" ]; then
     exit 0
 fi
 
+# isac status コマンドの検出: バージョン情報を含むフル出力を注入
+if echo "$QUERY" | grep -qiE '^isac[[:space:]]+status'; then
+    ISAC_BIN="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/bin/isac"
+    if [ -x "$ISAC_BIN" ]; then
+        echo ""
+        echo "## ISAC Status (CLI出力)"
+        echo "以下は \`isac status\` コマンドの実際の出力です。この内容をそのまま表示してください。"
+        echo '```'
+        "$ISAC_BIN" status 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || true
+        echo '```'
+        echo ""
+    fi
+fi
+
 # Memory Serviceが起動していない場合はスキップ
 if ! curl -s --connect-timeout 1 "$MEMORY_URL/health" > /dev/null 2>&1; then
     exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ isac status --no-cache
 export ISAC_NO_CACHE=1
 ```
 
+**Claude Code CLI での動作**: ユーザーが Claude Code CLI 内で `isac status` と入力した場合、on-prompt フックが `isac status` bash コマンドを自動実行し、バージョン情報を含むフル出力をコンテキストに注入する。Claude はこの出力をそのまま表示すること。
+
 ## コーディング規約
 
 ### Python


### PR DESCRIPTION
## Summary

- Claude Code CLI 内で `isac status` と入力した際にバージョン情報が表示されない問題を修正
- `on-prompt.sh` フックで `isac status` クエリを検出し、実際の bash コマンド出力をコンテキストに注入するようにした
- `CLAUDE.md` に Claude Code CLI での `isac status` の動作説明を追加

## Test plan

- [x] `bash tests/run_all_tests.sh --quick` 全テスト成功（44/44）
- [x] Claude Code CLI 内で `isac status` と入力し、バージョン情報（Version, Local, Status, Cache, Recent Changes）が表示されることを確認
- [x] 通常のクエリ（例: 「APIの設計について教えて」）が影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)