### PR TITLE
Add mcpServers to isac init template

### DIFF
--- a/bin/isac
+++ b/bin/isac
@@ -443,6 +443,7 @@ create_settings_yaml() {
 
     generate_mcp_block > "${mcp_file}"
 
+    # --- Part 1: ヘッダーコメント（使い方・仕組みの説明） ---
     cat > "${settings_file}" << 'SETTINGS_EOF'
 # ============================================================================
 # ISAC Project Settings for Claude Code CLI
@@ -497,9 +498,10 @@ create_settings_yaml() {
 #
 SETTINGS_EOF
 
-    # MCP ブロックをテンプレートに追記
+    # --- Part 2: MCP ブロック（マーカー付き、isac init --force で更新対象） ---
     cat "${mcp_file}" >> "${settings_file}"
 
+    # --- Part 3: フッター（カスタマイズ例・FAQ） ---
     cat >> "${settings_file}" << 'SETTINGS_FOOTER_EOF'
 
 # ============================================================================
@@ -558,21 +560,28 @@ SETTINGS_FOOTER_EOF
 # 既存の settings.yaml に MCP セクションだけをマージ
 update_settings_mcp() {
     local settings_file=".claude/settings.yaml"
-    local tmp_file mcp_file
-    tmp_file=$(mktemp)
+    local mcp_file
     mcp_file=$(mktemp)
 
     generate_mcp_block > "${mcp_file}"
 
-    if grep -q "^# >>> ISAC-MANAGED: mcpServers" "${settings_file}"; then
+    # ファイルを1回走査してパターンを判定
+    local has_start_marker has_end_marker has_mcp
+    has_start_marker=$(grep -c "^# >>> ISAC-MANAGED: mcpServers" "${settings_file}" || true)
+    has_end_marker=$(grep -c "^# <<< ISAC-MANAGED: mcpServers" "${settings_file}" || true)
+    has_mcp=$(grep -c "^mcpServers:" "${settings_file}" || true)
+
+    if [ "${has_start_marker}" -gt 0 ]; then
         # 終了マーカーの存在を確認
-        if ! grep -q "^# <<< ISAC-MANAGED: mcpServers" "${settings_file}"; then
+        if [ "${has_end_marker}" -eq 0 ]; then
             echo -e "  ${YELLOW}⚠${NC} End marker missing in .claude/settings.yaml, skipping update"
             echo "     Please fix or delete the '# >>> ISAC-MANAGED: mcpServers' line manually."
-            rm -f "${tmp_file}" "${mcp_file}"
+            rm -f "${mcp_file}"
             return
         fi
         # マーカーが存在 → セクションを差し替え
+        local tmp_file
+        tmp_file=$(mktemp)
         awk -v mcp_file="${mcp_file}" '
         /^# >>> ISAC-MANAGED: mcpServers/ {
             while ((getline line < mcp_file) > 0) print line
@@ -588,7 +597,7 @@ update_settings_mcp() {
         ' "${settings_file}" > "${tmp_file}"
         mv "${tmp_file}" "${settings_file}"
         echo -e "  ${GREEN}✓${NC} Updated mcpServers in .claude/settings.yaml"
-    elif grep -q "^mcpServers:" "${settings_file}"; then
+    elif [ "${has_mcp}" -gt 0 ]; then
         # ユーザー独自の mcpServers がある → 警告のみ
         echo -e "  ${YELLOW}⚠${NC} mcpServers section exists (user-managed), skipping"
         echo "     To use ISAC-managed MCP settings, remove your mcpServers section"
@@ -602,7 +611,7 @@ update_settings_mcp() {
         echo -e "  ${GREEN}✓${NC} Added mcpServers to .claude/settings.yaml"
     fi
 
-    rm -f "${tmp_file}" "${mcp_file}"
+    rm -f "${mcp_file}"
 }
 
 # .claude/ ディレクトリのセットアップ


### PR DESCRIPTION
## Summary

- `isac init` で生成される `.claude/settings.yaml` テンプレートに `mcpServers` セクション（notion, context7）を追加
- 既存の settings.yaml がある場合は MCP セクションだけを安全にマージ（マーカーベース）
- 環境変数のセットアップ方法をコメントに記載

## Background

開発プロジェクト側で MCP サーバーが見えない問題があった。hooks/skills はシンボリックリンクで伝播されるが、MCP 設定はテンプレートに含まれておらず手動追加が必要だった。

10人のペルソナでレビューした結果、テンプレートに含める案（A案）を6票で採用。実装後の品質レビュー（10人）でテスト追加と終了マーカー防御を指摘され対応済み。

## Changes

### `bin/isac`
- `generate_mcp_block()`: マーカー付き MCP 設定ブロック生成
- `create_settings_yaml()`: テンプレート全体を新規作成（MCP ブロック含む）
- `update_settings_mcp()`: 既存ファイルに MCP セクションだけをマージ
  - マーカーあり → セクション差し替え
  - マーカーなし・MCP なし → 末尾に追記
  - ユーザー独自 mcpServers → スキップ（警告表示）
  - 終了マーカー欠落 → スキップ（ファイル保護）
- `setup_claude_directory()`: 既存ファイル有無で作成/マージを分岐

### `tests/test_hooks.sh`
- MCP マージ関連テスト 7 件追加（テスト10-16）

## Test plan

- [x] `bash tests/run_all_tests.sh --quick` 全テスト通過（51/51）
- [x] 新規作成で mcpServers とマーカーが含まれる
- [x] `--force` で既存カスタム設定が保持される
- [x] `--force` で mcpServers が更新される
- [x] マーカーなし既存ファイルへの追記
- [x] ユーザー独自 mcpServers のスキップ
- [x] 終了マーカー欠落時のファイル保護
- [ ] 新規ディレクトリで `isac init --yes` → `claude` 起動で MCP 認識を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)