### PR TITLE
Fix CLI and Hooks issues with comprehensive tests

### DIFF
--- a/.claude/hooks/on-prompt.sh
+++ b/.claude/hooks/on-prompt.sh
@@ -85,16 +85,19 @@ if [ -n "$PROJECT_WARNING" ]; then
 fi
 
 # コンテキスト取得（Team IDがあればヘッダーに追加）
+# URLエンコード（パス部分に使用するため）
+ENCODED_PROJECT_ID=$(printf '%s' "$PROJECT_ID" | jq -sRr @uri 2>/dev/null || printf '%s' "$PROJECT_ID" | sed 's/ /%20/g; s/&/%26/g; s/?/%3F/g; s/#/%23/g; s|/|%2F|g')
+
 CONTEXT=""
 if [ -n "$TEAM_ID" ]; then
-    CONTEXT=$(curl -s --max-time 5 "$MEMORY_URL/context/$PROJECT_ID" \
+    CONTEXT=$(curl -s --max-time 5 "$MEMORY_URL/context/$ENCODED_PROJECT_ID" \
         --get \
         --data-urlencode "query=$QUERY" \
         --data-urlencode "max_tokens=$MAX_TOKENS" \
         -H "X-Team-Id: $TEAM_ID" \
         2>/dev/null || echo "")
 else
-    CONTEXT=$(curl -s --max-time 5 "$MEMORY_URL/context/$PROJECT_ID" \
+    CONTEXT=$(curl -s --max-time 5 "$MEMORY_URL/context/$ENCODED_PROJECT_ID" \
         --get \
         --data-urlencode "query=$QUERY" \
         --data-urlencode "max_tokens=$MAX_TOKENS" \

--- a/.claude/hooks/post-edit.sh
+++ b/.claude/hooks/post-edit.sh
@@ -233,24 +233,37 @@ case "$EXTENSION" in
         ;;
 esac
 
-# Memory Serviceに保存
+# Memory Serviceに保存（jqで安全にJSONを構築）
+PAYLOAD=$(jq -n \
+    --arg content "$SUMMARY" \
+    --arg scope_id "$PROJECT_ID" \
+    --arg category "$AUTO_CATEGORY" \
+    --argjson tags "$AUTO_TAGS" \
+    --arg file "$FILE_PATH" \
+    --arg filename "$FILENAME" \
+    --arg extension "$EXTENSION" \
+    --arg directory "$DIRNAME" \
+    --arg user "$USER_ID" \
+    --arg team_id "$TEAM_ID" \
+    '{
+        content: $content,
+        type: "work",
+        importance: 0.3,
+        scope: "project",
+        scope_id: $scope_id,
+        category: $category,
+        tags: $tags,
+        metadata: {
+            file: $file,
+            filename: $filename,
+            extension: $extension,
+            directory: $directory,
+            action: "edit",
+            user: $user,
+            team_id: $team_id
+        }
+    }')
+
 curl -s --max-time 3 -X POST "$MEMORY_URL/store" \
     -H "Content-Type: application/json" \
-    -d "{
-        \"content\": \"$SUMMARY\",
-        \"type\": \"work\",
-        \"importance\": 0.3,
-        \"scope\": \"project\",
-        \"scope_id\": \"$PROJECT_ID\",
-        \"category\": \"$AUTO_CATEGORY\",
-        \"tags\": $AUTO_TAGS,
-        \"metadata\": {
-            \"file\": \"$FILE_PATH\",
-            \"filename\": \"$FILENAME\",
-            \"extension\": \"$EXTENSION\",
-            \"directory\": \"$DIRNAME\",
-            \"action\": \"edit\",
-            \"user\": \"$USER_ID\",
-            \"team_id\": \"$TEAM_ID\"
-        }
-    }" > /dev/null 2>&1 || true
+    -d "$PAYLOAD" > /dev/null 2>&1 || true

--- a/.claude/hooks/sensitive-filter.sh
+++ b/.claude/hooks/sensitive-filter.sh
@@ -56,6 +56,23 @@ PATTERNS=(
     # Context7 API Key
     "context7_api_key:ctx7sk-[0-9a-f-]{36}"
 
+    # GitHub Token
+    "github_token:ghp_[A-Za-z0-9]{36}"
+    "github_token:gho_[A-Za-z0-9]{36}"
+    "github_token:ghu_[A-Za-z0-9]{36}"
+    "github_token:ghs_[A-Za-z0-9]{36}"
+    "github_token:ghr_[A-Za-z0-9]{36}"
+
+    # Slack Token
+    "slack_token:xoxb-[0-9A-Za-z-]+"
+    "slack_token:xoxp-[0-9A-Za-z-]+"
+    "slack_token:xoxa-[0-9A-Za-z-]+"
+    "slack_token:xoxr-[0-9A-Za-z-]+"
+
+    # Notion Token
+    "notion_token:ntn_[A-Za-z0-9]+"
+    "notion_token:secret_[A-Za-z0-9]+"
+
     # Generic secrets（8文字以上）
     "secret:secret[[:space:]]*[=:][[:space:]]*['\"]?[^[:space:]'\"]{8,}['\"]?"
     "credential:credential[[:space:]]*[=:][[:space:]]*['\"]?[^[:space:]'\"]{8,}['\"]?"
@@ -72,7 +89,8 @@ for pattern_def in "${PATTERNS[@]}"; do
     PATTERN_REGEX="${pattern_def#*:}"
 
     # 大文字小文字を無視してマッチ
-    if echo "$INPUT_TEXT" | grep -iE "$PATTERN_REGEX" > /dev/null 2>&1; then
+    # Note: `--` は必須（パターンが "-" で始まる場合にオプションとして解釈されるのを防ぐ）
+    if echo "$INPUT_TEXT" | grep -iE -- "$PATTERN_REGEX" > /dev/null 2>&1; then
         DETECTED+=("$PATTERN_NAME")
         IS_SENSITIVE="true"
 


### PR DESCRIPTION
## 概要

- CLIコマンドの問題修正（スキルカウント、ステップ番号、プロジェクトIDバリデーション）
- Hooksのセキュリティ問題修正（JSONエスケープ、URLエンコーディング）
- 包括的なエッジケーステスト追加（合計124テスト: CLI 50件 + Hooks 74件）

## CLI修正

- スキルカウント表示を修正（`*.md` ではなくディレクトリをカウント）
- updateコマンドのステップ番号を修正（`[1/3]` → `[1/4]`）
- `validate_project_id()` 関数を追加（入力バリデーション）
- switchコマンドにURLエンコーディングを追加
- switchコマンドに `--yes` オプションを追加（CI/CD対応）

## Hooks修正

| ファイル | 修正内容 |
|---------|---------|
| `resolve-project.sh` | jqによる安全なJSONエスケープ、プロジェクト提案APIのURLエンコーディング追加 |
| `on-prompt.sh` | 特殊文字を含むプロジェクトIDのURLエンコーディング追加（/, &, スペース, 日本語） |
| `post-edit.sh` | 安全でない文字列補間をjqによるJSON構築に置換 |
| `save-memory.sh` | 安全でない文字列補間をjqによるJSON構築に置換 |
| `sensitive-filter.sh` | GitHub/Slack/Notion/Context7トークン検出パターン追加、ダッシュで始まるパターンのgrep処理修正 |

## テストカバレッジ

- **test_cli.sh**: バリデーション、セキュリティ、境界値をカバーする50テスト
- **test_hooks.sh**: JSONエスケープ、URLエンコーディング、トークン検出、エッジケースをカバーする74テスト

## テスト結果

```
CLI Tests:         50/50 PASSED
Hook Tests:        74/74 PASSED
Integration Tests: 13/13 PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)