### PR TITLE
Memory Serviceにgithubカテゴリを追加

### DIFF
--- a/memory-service/main.py
+++ b/memory-service/main.py
@@ -87,6 +87,7 @@ class MemoryCategory(str, Enum):
     TEST = "test"              # テスト
     DOCS = "docs"              # ドキュメント
     ARCHITECTURE = "architecture"  # アーキテクチャ
+    GITHUB = "github"          # GitHub運用（Issue、PR、ラベル等）
     OTHER = "other"            # その他
 
 
@@ -1476,6 +1477,7 @@ async def list_categories():
             "test": "テスト",
             "docs": "ドキュメント",
             "architecture": "アーキテクチャ設計",
+            "github": "GitHub運用（Issue、PR、ラベル等）",
             "other": "その他"
         }
     }


### PR DESCRIPTION
## Summary
- Memory Serviceのカテゴリに `github` を追加
- GitHub運用（Issue、PR、ラベル等）に関する記憶を分類可能に
- カテゴリ機能のテストを追加（6件）

## 変更内容

### Memory Service
- `MemoryCategory` Enumに `GITHUB = "github"` を追加
- カテゴリ説明に「GitHub運用（Issue、PR、ラベル等）」を追加

### テスト
- `TestCategories` クラスを新規追加
  - `test_list_categories`: カテゴリ一覧取得
  - `test_github_category_exists`: githubカテゴリの存在確認
  - `test_store_with_github_category`: githubカテゴリでの保存
  - `test_search_by_category`: カテゴリでのフィルタリング検索
  - `test_update_category`: カテゴリの更新
  - `test_invalid_category_rejected`: 無効カテゴリの拒否
- 廃止済み検索テストの修正（importance設定追加）

## 背景
10人のペルソナでレビューし、GitHub運用ルールを分類するためのカテゴリが必要と判断。

## Test plan
- [x] `pytest tests/test_memory_service.py -v` で全44テストが通過
- [x] Memory Serviceを再起動後、`/categories` で `github` が返される

🤖 Generated with [Claude Code](https://claude.com/claude-code)