### PR TITLE
Search APIバリデーション強化: offset追加・空コンテンツ拒否・limit上限拡大

### DIFF
--- a/tests/test_memory_service.py
+++ b/tests/test_memory_service.py
@@ -2673,18 +2673,12 @@ class TestBoundaryValuesComprehensive:
         assert len(data["memories"]) <= 50
 
     def test_limit_over_max_rejected(self):
-        """limit>50は拒否または制限される"""
+        """limit>100は拒否される"""
         response = requests.get(
             f"{BASE_URL}/search",
-            params={"query": "テスト", "limit": 100}
+            params={"query": "テスト", "limit": 101}
         )
-        # 100は拒否されるか、50に制限されるべき
-        if response.status_code == 200:
-            data = response.json()
-            # 結果が50以下に制限されていることを確認
-            assert len(data["memories"]) <= 50, f"limit=100 で {len(data['memories'])} 件返されました"
-        else:
-            assert response.status_code in [400, 422], f"予期しないステータスコード: {response.status_code}"
+        assert response.status_code == 422, f"limit=101 が受け入れられました: {response.status_code}"
 
     def test_offset_zero(self):
         """offset=0 での検索ができる"""


### PR DESCRIPTION
## Summary

- Search APIに`offset`パラメータを追加（ページネーション対応）
- 空コンテンツのバリデーション追加（store/update両エンドポイント）
- Search APIの`limit`上限を50→100に拡大
- DB取得量をoffset考慮に修正（大きなoffsetでも正しく動作）

## 変更内容

### memory-service/main.py
- `validate_content_not_empty()` ヘルパー関数追加
- `store_memory`: 空コンテンツを422で拒否
- `update_memory`: 空コンテンツを422で拒否（レビュー指摘で追加）
- `search_memories`: `offset`パラメータ追加（`ge=0`、負の値は422）
- `search_memories`: `limit`上限を`le=50`→`le=100`に拡大
- DB取得量を`limit * 5`→`(offset + limit) * 5`に修正

### tests/test_memory_service.py
- `test_limit_over_max_rejected`: limit=100→101に修正（上限100対応）

### tests/test_todo.sh
- テスト15「空文字タスク」: 「保存される」→「拒否される（422）」に修正
- 未使用変数`HTTP_CODE`を削除

## 修正されたテスト失敗（4件→0件）

| テスト | 原因 | 修正 |
|--------|------|------|
| `test_empty_content_rejected` | 空コンテンツ未チェック | `validate_content_not_empty()` 追加 |
| `test_negative_offset_rejected` | offsetパラメータ未実装 | `offset: int = Query(0, ge=0)` 追加 |
| `test_offset_large_value` | offsetパラメータ未実装 | offset/limitをスライスで適用 |
| `test_search_limit_large` | limit上限が50 | `le=100`に拡大 |

## Test plan

- [x] pytest 215 passed, 0 failed
- [x] Hooks 72 passed, 0 failed
- [x] 統合テスト 13 passed, 0 failed
- [x] Todoテスト 21 passed, 0 failed
- [x] コードレビュー実施済み（88→100点）

🤖 Generated with [Claude Code](https://claude.com/claude-code)