### PR TITLE
isac init で既存の .isac.yaml から project_id を引き継ぐ機能を追加

### DIFF
--- a/bin/isac
+++ b/bin/isac
@@ -342,8 +342,15 @@ cmd_init() {
     echo ""
 
     # プロジェクトIDの決定
+    # 優先順位: 引数 > 既存 .isac.yaml > ディレクトリ名（basename）
     if [ -z "${project_id}" ]; then
-        project_id="$(basename "$(pwd)")"
+        # 既存の.isac.yamlからproject_idを引き継ぐ
+        if [ -f ".isac.yaml" ]; then
+            project_id=$(grep -E "^project_id:" .isac.yaml | sed 's/project_id: *//' | tr -d "\"'" || true)
+        fi
+        if [ -z "${project_id}" ]; then
+            project_id="$(basename "$(pwd)")"
+        fi
         if [ "${flag_yes}" = false ]; then
             echo -n "Project ID [${project_id}]: "
             read -r input_id


### PR DESCRIPTION
## 概要

`isac init` で再初期化する際、既存の `.isac.yaml` に記載されている `project_id` をデフォルト値として引き継ぐようにした。

## 背景

従来は `isac init` の project_id デフォルト値がディレクトリ名（basename）固定だったため、再初期化時に毎回 project_id を手動入力する必要があった。

## 変更内容

- `bin/isac` の `cmd_init()` 内の project_id デフォルト値決定ロジックを変更
- 優先順位: **引数 > 既存 `.isac.yaml` > ディレクトリ名（basename）**
- テストケース6件を `tests/test_cli.sh` に追加

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `bin/isac` | project_id 引き継ぎロジック追加（+7行） |
| `tests/test_cli.sh` | テスト12.5（6ケース）追加 |

### テストケース

| # | テスト内容 | 結果 |
|---|-----------|------|
| 12.5-1 | 既存の .isac.yaml から project_id を引き継ぐ | PASS |
| 12.5-2 | 引数が既存 .isac.yaml より優先される | PASS |
| 12.5-3 | .isac.yaml が存在しない場合はディレクトリ名がデフォルト | PASS |
| 12.5-4 | .isac.yaml に project_id がない場合はディレクトリ名がデフォルト | PASS |
| 12.5-5 | ダブルクォート付き project_id の引き継ぎ | PASS |
| 12.5-6 | シングルクォート付き project_id の引き継ぎ | PASS |

## テスト結果

全テストスイート通過済み（`bash tests/run_all_tests.sh --quick`）:
- Hook Tests: PASSED
- Integration Tests: PASSED
- Todo Tests: PASSED
- CLI Tests: PASSED (83/83)

## レビュー済み

3人のペルソナレビューで全員賛成。設計として正しいことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)