### PR TITLE
docker-compose.test.ymlのサービス名衝突を修正

### DIFF
--- a/memory-service/README.md
+++ b/memory-service/README.md
@@ -280,9 +280,12 @@ DELETE /memory/{id}
 
 ### テスト環境の起動
 
+> **注意**: テスト用 `docker-compose.test.yml` のサービス名は `memory-test`（本番は `memory`）です。
+> 手動起動時は `-p` フラグでプロジェクト名を分離し、本番コンテナとの干渉を防いでください。
+
 ```bash
 cd memory-service
-docker compose -f docker-compose.test.yml up -d --build
+docker compose -p isac-memory-test -f docker-compose.test.yml up -d --build
 ```
 
 ### テストの実行
@@ -299,5 +302,5 @@ pytest tests/test_permission.py -v
 
 ```bash
 cd memory-service
-docker compose -f docker-compose.test.yml down -v
+docker compose -p isac-memory-test -f docker-compose.test.yml down -v
 ```

--- a/memory-service/docker-compose.test.yml
+++ b/memory-service/docker-compose.test.yml
@@ -5,7 +5,7 @@ version: '3.8'
 # 認証を有効化し、テスト用の Admin API キーを設定
 
 services:
-  memory:
+  memory-test:
     build: .
     container_name: isac-memory-test
     ports:

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,18 @@ pip install -r tests/requirements.txt
 > **注意**: テスト用 Memory Service はポート **8200** で起動します。
 > 通常運用（ポート 8100）とは分離されているため、テスト中も通常サービスに影響しません。
 
+> **手動起動時の注意**: `docker-compose.test.yml` のサービス名は `memory-test`（本番は `memory`）です。
+> 手動でテスト用コンテナを起動する場合は、必ず `-p` フラグでプロジェクト名を指定してください。
+> `-p` を省略すると、同じディレクトリ内の本番コンテナと干渉する可能性があります。
+>
+> ```bash
+> # 推奨: -p でプロジェクト名を分離
+> docker compose -p isac-memory-test -f docker-compose.test.yml up -d --build
+>
+> # 停止時も同じプロジェクト名を指定
+> docker compose -p isac-memory-test -f docker-compose.test.yml down -v
+> ```
+
 ## テスト実行
 
 ### クイックテスト（推奨）
@@ -130,11 +142,11 @@ bash tests/run_all_tests.sh --help
 # テスト用コンテナの起動確認
 curl http://localhost:8200/health
 
-# テスト用コンテナの手動起動
-cd memory-service && docker compose -f docker-compose.test.yml up -d --build
+# テスト用コンテナの手動起動（-p でプロジェクト名を分離）
+cd memory-service && docker compose -p isac-memory-test -f docker-compose.test.yml up -d --build
 
 # テスト用コンテナのログ確認
-docker compose -f memory-service/docker-compose.test.yml logs
+docker compose -p isac-memory-test -f memory-service/docker-compose.test.yml logs
 ```
 
 ### jq が見つからない

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ ISAC Memory Service テスト用 pytest 設定
 
 テスト実行前に必要な環境:
     cd memory-service
-    docker compose -f docker-compose.test.yml up -d --build
+    docker compose -p isac-memory-test -f docker-compose.test.yml up -d --build
 """
 
 import os

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -5,7 +5,7 @@ ISAC Memory Service 権限テスト
 
 実行方法:
     cd memory-service
-    docker compose -f docker-compose.test.yml up -d --build
+    docker compose -p isac-memory-test -f docker-compose.test.yml up -d --build
     cd ..
     pytest tests/test_permission.py -v
 """


### PR DESCRIPTION
## 概要

本番(`docker-compose.yml`)とテスト(`docker-compose.test.yml`)で同じサービス名 `memory` を使っていたため、テストコンテナ起動時に本番コンテナが Recreate（削除→再作成）されて消滅する問題を修正します。

## 設計決定

Memory ID: `0a2413b5` で決定済み。10人のペルソナでレビュー実施、A案（サービス名変更）で全員合意。

## 変更内容

### 1. サービス名の分離
- `docker-compose.test.yml` のサービス名を `memory` から `memory-test` に変更
- `container_name` は既に `isac-memory-test` で分離済み（変更なし）

### 2. ドキュメント更新
- `tests/README.md`: 手動起動時の注意事項を追記（サービス名の違い、`-p` フラグ推奨）
- `memory-service/README.md`: テスト環境の起動/停止手順に `-p` フラグと注意事項を追記
- `tests/conftest.py`, `tests/test_permission.py`: コメント内の手動起動コマンドに `-p` フラグを追記

## テスト結果

`bash tests/run_all_tests.sh --quick` で全テスト成功:
- Hook Tests: 73 PASSED
- Integration Tests: 13 PASSED
- Todo Tests: 21 PASSED
- CLI Tests: 83 PASSED

## テスト計画

- [x] テスト用コンテナがサービス名 `memory-test` で正常に起動すること
- [x] テストランナー (`run_all_tests.sh`) が正常に動作すること
- [x] 本番コンテナ（ポート8100）が起動中でもテストコンテナが干渉しないこと
- [x] 全既存テストが PASSED すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)