### PR TITLE
isac init --forceでsettings.yamlを自動削除する機能を追加

### DIFF
--- a/bin/isac
+++ b/bin/isac
@@ -676,10 +676,15 @@ setup_claude_directory() {
         create_settings_json
     fi
 
-    # 古い settings.yaml が残っている場合に警告
+    # 古い settings.yaml が残っている場合
     if [ -f ".claude/settings.yaml" ]; then
-        echo -e "  ${YELLOW}⚠${NC} .claude/settings.yaml is deprecated (Claude Code CLI uses settings.json)"
-        echo "     You can safely delete .claude/settings.yaml"
+        if [ "${force}" = true ]; then
+            rm -f .claude/settings.yaml
+            echo -e "  ${GREEN}✓${NC} Removed deprecated .claude/settings.yaml"
+        else
+            echo -e "  ${YELLOW}⚠${NC} .claude/settings.yaml is deprecated (Claude Code CLI uses settings.json)"
+            echo "     Run 'isac init --force' to remove it automatically"
+        fi
     fi
 
     echo -e "  ${GREEN}✓${NC} .claude/settings.json ready"


### PR DESCRIPTION
## Summary

`isac init --force` 実行時に古い `.claude/settings.yaml` を自動削除する機能を追加。通常の `isac init` では警告メッセージのみ表示（現状維持）。

## Design

### 変更対象ファイル

| ファイル | 変更内容 |
|---------|---------|
| `bin/isac` | `setup_claude_directory()` 内の settings.yaml 処理を force 分岐に変更 |
| `tests/test_hooks.sh` | settings.yaml 自動削除に関するテスト3件を追加 |

### 実装方針

既存の `setup_claude_directory()` 関数内で settings.yaml の存在チェック後に `force` パラメータで分岐を追加。`force=true` の場合は `rm -f` で削除しログ出力、`false` の場合は従来の警告メッセージ（`isac init --force` への案内も追加）を表示。変更量は最小限（3行追加）。

## Changes

- `bin/isac`: `setup_claude_directory()` 内の settings.yaml 処理に force 分岐を追加
  - `--force` 時: `rm -f .claude/settings.yaml` で自動削除、削除完了ログを出力
  - 通常時: 警告メッセージに `isac init --force` による自動削除の案内を追加
- `tests/test_hooks.sh`: テスト3件追加
  - `isac init --force` で settings.yaml が自動削除されること
  - 削除時にログメッセージが出力されること
  - `--force` なしでは settings.yaml が残ること

## Review Score

- Final Score: 96/100
- Review Iterations: 1

### レビュー詳細

#### 観点別スコア

| 観点 | スコア | 理由 |
|------|--------|------|
| セキュリティ | 95/100 | `rm -f` は固定パスのみを対象、パストラバーサルリスクなし |
| パフォーマンス | 98/100 | `rm -f` は瞬時完了、5秒制約に影響なし |
| 保守性 | 95/100 | 既存の if 分岐に3行追加のみ、テスト3件で十分な網羅性 |

## Test Results

- Status: Passed
- Test Command: `bash tests/run_all_tests.sh --quick`

---

🤖 This PR was created by [ISAC Autopilot](https://github.com/kita-tech/isac)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>