### PR TITLE
Memory Service REST API 維持の設計根拠をドキュメント化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,8 +360,10 @@ gh pr create --title "Add [hook-name] hook" --body "..."
 | CLI コマンド追加・変更 | CLAUDE.md（コマンドセクション） |
 | Skill 追加・変更 | CLAUDE.md（Skills一覧）、SKILL.md |
 | Hooks 追加・変更 | CLAUDE.md（ディレクトリ構成） |
-| API 追加・変更 | CLAUDE.md（API セクション）、memory-service/README.md |
+| API 追加・変更 | CLAUDE.md（API セクション）、[docs/MEMORY_SERVICE.md](docs/MEMORY_SERVICE.md) |
 | 設計決定 | CLAUDE.md（技術的決定事項） |
+| Memory Service アーキテクチャ | [docs/MEMORY_SERVICE.md](docs/MEMORY_SERVICE.md) |
+| テスト設計 | [docs/TEST_DESIGN_GUIDE.md](docs/TEST_DESIGN_GUIDE.md) |
 
 ### 3. PR作成前チェックリスト
 


### PR DESCRIPTION
## Summary
- Claude Code Plugin システムを調査し、Memory Service を MCP 化せず REST API を維持する設計判断をドキュメント化
- CLAUDE.md のドキュメント更新対象表に `docs/` 配下ファイルへの参照を追加

## 変更内容
- **docs/MEMORY_SERVICE.md**: 「なぜ MCP ではなく REST API か？」セクションを追加
  - バックグラウンドサブエージェントで MCP ツール使用不可（Claude Code 公式ドキュメントに明記）
  - Hooks（シェルスクリプト）から MCP は呼べない
  - curl であらゆるコンテキストからアクセス可能
  - クラウド移行時の互換性
- **CLAUDE.md**: ドキュメント更新対象表に `docs/MEMORY_SERVICE.md` と `docs/TEST_DESIGN_GUIDE.md` の参照を追加

## 背景
- Claude Code Plugin システムは Skills/Hooks/MCP/Agents/LSP をパッケージ配布する公式機能
- ISAC の Memory Service を MCP 化すればPlugin に統合できるように見えるが、公式制約により不適切
- 10人のペルソナレビューで全員一致で「現状維持が妥当」と結論
- Memory Service 決定 ID: `20faa1c6`

## Test plan
- [ ] ドキュメントの内容が正確であることを確認
- [ ] CLAUDE.md のリンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)