### PR TITLE
isac install/update にステータスライン自動セットアップを統合

### DIFF
--- a/bin/isac
+++ b/bin/isac
@@ -154,13 +154,13 @@ cmd_install() {
     echo ""
 
     # ディレクトリ作成
-    echo -e "${GREEN}[1/5] Creating ~/.isac/ directory...${NC}"
+    echo -e "${GREEN}[1/7] Creating ~/.isac/ directory...${NC}"
     mkdir -p "${ISAC_GLOBAL_DIR}"
     mkdir -p "${ISAC_GLOBAL_DIR}/logs"
     chmod 700 "${ISAC_GLOBAL_DIR}"
 
     # Hooks コピー
-    echo -e "${GREEN}[2/5] Installing hooks...${NC}"
+    echo -e "${GREEN}[2/7] Installing hooks...${NC}"
     mkdir -p "${ISAC_GLOBAL_DIR}/hooks"
     if [ -d "${ISAC_SOURCE_DIR}/.claude/hooks" ]; then
         cp -f "${ISAC_SOURCE_DIR}/.claude/hooks/"*.sh "${ISAC_GLOBAL_DIR}/hooks/" 2>/dev/null || true
@@ -171,7 +171,7 @@ cmd_install() {
     fi
 
     # Skills コピー（ディレクトリ構造）
-    echo -e "${GREEN}[3/5] Installing skills...${NC}"
+    echo -e "${GREEN}[3/7] Installing skills...${NC}"
     mkdir -p "${ISAC_GLOBAL_DIR}/skills"
     if [ -d "${ISAC_SOURCE_DIR}/.claude/skills" ]; then
         # 既存のスキルを削除して再コピー
@@ -189,7 +189,7 @@ cmd_install() {
     fi
 
     # Agents コピー（SubAgent定義）
-    echo -e "${GREEN}[4/5] Installing agents...${NC}"
+    echo -e "${GREEN}[4/7] Installing agents...${NC}"
     mkdir -p "${ISAC_GLOBAL_DIR}/agents"
     if [ -d "${ISAC_SOURCE_DIR}/.claude/agents" ]; then
         cp -f "${ISAC_SOURCE_DIR}/.claude/agents/"*.md "${ISAC_GLOBAL_DIR}/agents/" 2>/dev/null || true
@@ -199,7 +199,7 @@ cmd_install() {
     fi
 
     # CLAUDE.md コピー（~/.isac/CLAUDE.md → ~/.claude/CLAUDE.md）
-    echo -e "${GREEN}[5/6] Setting up CLAUDE.md...${NC}"
+    echo -e "${GREEN}[5/7] Setting up CLAUDE.md...${NC}"
     if [ -f "${ISAC_SOURCE_DIR}/templates/CLAUDE.md.template" ]; then
         # テンプレートから~/.isac/CLAUDE.md を作成（言語設定セクションのみ抽出）
         if [ ! -f "${ISAC_GLOBAL_DIR}/CLAUDE.md" ]; then
@@ -221,8 +221,12 @@ CLAUDEMD_EOF
         echo -e "  Copied to ~/.claude/CLAUDE.md"
     fi
 
+    # Statusline セットアップ
+    echo -e "${GREEN}[6/7] Setting up statusline...${NC}"
+    setup_statusline
+
     # 設定ファイル作成
-    echo -e "${GREEN}[6/6] Creating config.yaml...${NC}"
+    echo -e "${GREEN}[7/7] Creating config.yaml...${NC}"
     if [ ! -f "${ISAC_GLOBAL_DIR}/config.yaml" ]; then
         cat > "${ISAC_GLOBAL_DIR}/config.yaml" << 'EOF'
 # ISAC Global Configuration
@@ -268,7 +272,7 @@ cmd_update() {
     fi
 
     # Hooks 更新
-    echo -e "${GREEN}[1/4] Updating hooks...${NC}"
+    echo -e "${GREEN}[1/5] Updating hooks...${NC}"
     if [ -d "${ISAC_SOURCE_DIR}/.claude/hooks" ]; then
         cp -f "${ISAC_SOURCE_DIR}/.claude/hooks/"*.sh "${ISAC_GLOBAL_DIR}/hooks/" 2>/dev/null || true
         chmod +x "${ISAC_GLOBAL_DIR}/hooks/"*.sh 2>/dev/null || true
@@ -276,7 +280,7 @@ cmd_update() {
     fi
 
     # Skills 更新（ディレクトリ構造）
-    echo -e "${GREEN}[2/4] Updating skills...${NC}"
+    echo -e "${GREEN}[2/5] Updating skills...${NC}"
     if [ -d "${ISAC_SOURCE_DIR}/.claude/skills" ]; then
         rm -rf "${ISAC_GLOBAL_DIR}/skills/"*
         cp -rf "${ISAC_SOURCE_DIR}/.claude/skills/"* "${ISAC_GLOBAL_DIR}/skills/" 2>/dev/null || true
@@ -290,7 +294,7 @@ cmd_update() {
     fi
 
     # Agents 更新
-    echo -e "${GREEN}[3/4] Updating agents...${NC}"
+    echo -e "${GREEN}[3/5] Updating agents...${NC}"
     mkdir -p "${ISAC_GLOBAL_DIR}/agents"
     if [ -d "${ISAC_SOURCE_DIR}/.claude/agents" ]; then
         cp -f "${ISAC_SOURCE_DIR}/.claude/agents/"*.md "${ISAC_GLOBAL_DIR}/agents/" 2>/dev/null || true
@@ -298,7 +302,7 @@ cmd_update() {
     fi
 
     # CLAUDE.md 更新（~/.isac/CLAUDE.md → ~/.claude/CLAUDE.md）
-    echo -e "${GREEN}[4/4] Updating CLAUDE.md...${NC}"
+    echo -e "${GREEN}[4/5] Updating CLAUDE.md...${NC}"
     if [ -f "${ISAC_GLOBAL_DIR}/CLAUDE.md" ]; then
         mkdir -p "${HOME}/.claude"
         cp -f "${ISAC_GLOBAL_DIR}/CLAUDE.md" "${HOME}/.claude/CLAUDE.md"
@@ -306,6 +310,10 @@ cmd_update() {
     else
         echo -e "  ${YELLOW}~/.isac/CLAUDE.md not found, skipping${NC}"
     fi
+
+    # Statusline 更新
+    echo -e "${GREEN}[5/5] Updating statusline...${NC}"
+    setup_statusline
 
     echo ""
     echo -e "${GREEN}Update complete!${NC}"
@@ -610,6 +618,39 @@ setup_mcp_servers() {
         -e "DEFAULT_MINIMUM_TOKENS=10000" \
         -e "CONTEXT7_API_KEY=${CONTEXT7_API_KEY}" \
         context7 -- npx -y @upstash/context7-mcp
+}
+
+# Statusline セットアップ（install/update 共通）
+setup_statusline() {
+    local source_script="${ISAC_SOURCE_DIR}/statusline/statusline-command.sh"
+    local dest_script="${HOME}/.claude/statusline-command.sh"
+    local settings_file="${HOME}/.claude/settings.json"
+
+    # スクリプトのコピー
+    if [ -f "${source_script}" ]; then
+        mkdir -p "${HOME}/.claude"
+        cp -f "${source_script}" "${dest_script}"
+        chmod +x "${dest_script}"
+        echo -e "  Copied statusline-command.sh to ~/.claude/"
+    else
+        echo -e "  ${YELLOW}Warning: ${source_script} not found${NC}"
+        return 0
+    fi
+
+    # settings.json に statusLine 設定をマージ
+    local statusline_config='{"type":"command","command":"bash ~/.claude/statusline-command.sh"}'
+
+    if [ -f "${settings_file}" ]; then
+        # 既存ファイルに statusLine キーを追加/更新
+        local tmp_file
+        tmp_file=$(mktemp)
+        jq --argjson sl "${statusline_config}" '.statusLine = $sl' "${settings_file}" > "${tmp_file}" && mv "${tmp_file}" "${settings_file}"
+        echo -e "  Updated statusLine in ~/.claude/settings.json"
+    else
+        # 新規作成
+        jq -n --argjson sl "${statusline_config}" '{"statusLine": $sl}' > "${settings_file}"
+        echo -e "  Created ~/.claude/settings.json with statusLine"
+    fi
 }
 
 # settings.json を新規作成（Claude Code CLI 公式形式）

--- a/statusline/statusline-command.sh
+++ b/statusline/statusline-command.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# ISAC statusLine command for Claude Code CLI
+# Shows: [project_id] [Memory:ON|OFF] ~/path/to/dir
+
+input=$(cat)
+
+# Current working directory (abbreviated with ~ for home)
+cwd=$(echo "$input" | jq -r '.cwd')
+home="$HOME"
+case "$cwd" in
+  "$home"*)
+    display_dir="~${cwd#$home}"
+    ;;
+  *)
+    display_dir="$cwd"
+    ;;
+esac
+
+# Resolve project ID from .isac.yaml (search up from cwd)
+project_id=""
+dir="$cwd"
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/.isac.yaml" ]; then
+    project_id=$(grep -E '^project_id:' "$dir/.isac.yaml" 2>/dev/null | sed 's/^project_id:[[:space:]]*//' | tr -d '"' | tr -d "'" || true)
+    break
+  fi
+  dir=$(dirname "$dir")
+done
+
+# Memory Service health check (very short timeout to keep statusline fast)
+MEMORY_URL="${MEMORY_SERVICE_URL:-http://localhost:8100}"
+if curl -s --connect-timeout 0.3 --max-time 0.5 "$MEMORY_URL/health" > /dev/null 2>&1; then
+  memory_status="ON"
+else
+  memory_status="OFF"
+fi
+
+# Build output
+parts=""
+if [ -n "$project_id" ]; then
+  parts="[$project_id]"
+fi
+parts="$parts [Memory:$memory_status] $display_dir"
+
+echo "$parts"


### PR DESCRIPTION
## Summary
- Claude Code CLI のステータスラインにISAC固有の情報を表示するスクリプトをリポジトリに追加（`statusline/statusline-command.sh`）
- `isac install` と `isac update` でスクリプトのコピーと `~/.claude/settings.json` への設定マージを自動実行
- 表示内容: `[project_id] [Memory:ON|OFF] ~/path/to/dir`

## 変更内容
- **`statusline/statusline-command.sh`（新規）**: ステータスラインスクリプト本体
- **`bin/isac`（変更）**:
  - `setup_statusline()` ヘルパー関数を追加
  - `cmd_install()`: 6→7ステップに更新、`[6/7] Setting up statusline...` を追加
  - `cmd_update()`: 4→5ステップに更新、`[5/5] Updating statusline...` を追加

## Test plan
- [x] `statusline-command.sh` 単体テスト: `echo '{"cwd":"..."}' | bash statusline/statusline-command.sh` で正しく出力
- [x] `isac install` で `~/.claude/statusline-command.sh` がコピーされ、`~/.claude/settings.json` に `statusLine` が設定される
- [x] `isac update` でスクリプトが更新される
- [x] 他プロジェクトで `isac init` 後にステータスラインが反映されることを確認済み
- [x] `bash -n bin/isac` で構文エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)