### PR TITLE
autopilot の権限確認を減らす allowlist を settings.json に追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,20 @@
 {
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh pr:*)",
+      "Bash(pytest:*)",
+      "Bash(bash tests/run_all_tests.sh:*)",
+      "Bash(curl http://localhost:8100/*)",
+      "Bash(jq:*)",
+      "Bash(chmod:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /*)",
+      "Bash(git push --force:*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## 概要

`/isac-autopilot` 実行中に出るコマンド実行の許可プロンプトでテンポが落ちる問題への対策。チーム共有の `.claude/settings.json` に `permissions` を追加し、autopilot が多用するコマンドを事前許可する。

## 背景

- 従来、広い許可は `.claude/settings.local.json` の `Bash(*)` に置かれていたが、**このファイルは `.gitignore` 対象＝各自のローカル限定**。そのため他メンバー・他プロジェクトでは許可が効かず、autopilot 中に確認が頻発していた。
- autopilot は Task でサブエージェントを起動し `git`(12) `bash`(10) `gh`(4) `curl`(3) `pytest`(2) 等を多数実行するため、確認回数が多い。

## 変更内容

`.claude/settings.json`（team-shared）に以下を追加：

```json
"permissions": {
  "defaultMode": "acceptEdits",
  "allow": [
    "Bash(git:*)",
    "Bash(gh pr:*)",
    "Bash(pytest:*)",
    "Bash(bash tests/run_all_tests.sh:*)",
    "Bash(curl http://localhost:8100/*)",
    "Bash(jq:*)",
    "Bash(chmod:*)"
  ],
  "deny": [
    "Bash(rm -rf /*)",
    "Bash(git push --force:*)"
  ]
}
```

- `defaultMode: acceptEdits`: ファイル編集＋FS操作（mkdir/rm/cp/mv）の確認を省略
- `allow`: autopilot の常用コマンドを事前許可
- `deny`: 破壊的操作を明示ブロック（allow より優先）
- 既存の `hooks` 設定は温存

## 既知の注意点（レビュー観点）

1. **`defaultMode: acceptEdits` はチーム全員のデフォルト挙動を変える**。慎重運用したいメンバーは Shift+Tab で `default` に戻せる。
2. **`Bash(curl http://localhost:8100/*)` は変数経由の curl にマッチしない可能性**。ISAC スキルの多くは `curl -s "$MEMORY_URL/..."` 形式で、許可マッチャは展開前の文字列を見るため、リテラル URL ルールでは依然プロンプトが出ることがある。確実に消すなら `Bash(curl:*)` への緩和が必要（要判断）。
3. **`Bash(gh pr:*)` は `gh pr` 系のみ**。autopilot が `gh api` 等を使う場合は別途追加が必要。
4. `git push`（非force）は許可に含まれる（autopilot の Draft PR 作成に必要）。force push のみ deny。

## ローカル個別調整

各自の `.claude/settings.local.json` でさらに緩める/締めることが可能（local が project より優先）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)