### PR TITLE
todo の owner 未指定時の警告重複を解消

### DIFF
--- a/memory-service/main.py
+++ b/memory-service/main.py
@@ -297,6 +297,7 @@ def enforce_type_metadata(entry: "MemoryEntry", current_user: "Optional[CurrentU
         return warnings
 
     md = entry.metadata
+    warned_keys: set[str] = set()  # 既に専用メッセージで警告したキー（汎用チェックでの重複を防ぐ）
 
     # todo の owner 自動補完
     if entry.type == MemoryType.TODO and not md.get("owner"):
@@ -309,6 +310,7 @@ def enforce_type_metadata(entry: "MemoryEntry", current_user: "Optional[CurrentU
                 "owner の無い todo は /my/todos の owner フィルタに現れません。"
                 "isac-todo スキル経由での登録、または metadata.owner の明示指定を推奨します。"
             )
+            warned_keys.add("owner")
 
     # デフォルト値の補完（status など）
     for key, default_value in schema.get("defaults", {}).items():
@@ -316,8 +318,9 @@ def enforce_type_metadata(entry: "MemoryEntry", current_user: "Optional[CurrentU
             md[key] = default_value
 
     # required キーの欠落チェック（補完後にまだ無いものを警告）
+    # 専用メッセージで既に警告済みのキー（owner 等）は重複させない
     for key in schema.get("required", []):
-        if not md.get(key):
+        if not md.get(key) and key not in warned_keys:
             warnings.append(f"type={entry.type.value} に metadata.{key} が未指定です。")
 
     # enum 検証（不正値は明確なエラー）

--- a/tests/test_memory_service.py
+++ b/tests/test_memory_service.py
@@ -3138,7 +3138,10 @@ class TestTodoMetadata:
         assert response.status_code == 200
         data = response.json()
         assert data.get("warnings"), "owner 未指定時は warnings が返るべき"
-        assert any("owner" in w for w in data["warnings"])
+        owner_warnings = [w for w in data["warnings"] if "owner" in w]
+        assert owner_warnings, "owner に関する警告があるべき"
+        # owner の警告は1件のみ（専用メッセージと汎用必須チェックで重複しないこと）
+        assert len(owner_warnings) == 1, f"owner 警告が重複している: {owner_warnings}"
 
     def test_todo_owner_explicit_preserved(self):
         """owner を明示指定した場合はそのまま保持され、警告は出ない"""


### PR DESCRIPTION
## 概要

`type=todo` で `owner` 未指定（かつ匿名で自動補完不可）の場合、`POST /store` の `warnings` に
**同趣旨の owner 警告が2件**出ていた不具合を修正する。

```
["type=todo に metadata.owner が未指定です。owner の無い todo は…推奨します。",
 "type=todo に metadata.owner が未指定です。"]   ← 重複
```

## 原因

`enforce_type_metadata()`（#60 で追加）で owner 警告が2系統から append されていた：
- owner 専用ブランチ（詳細メッセージ）
- 汎用 `required` キー欠落チェック（`required: ["owner","status"]` を走査）

owner は自動補完に失敗すると両方に引っかかり重複。status は既定値補完で埋まるため重複しない。

## 修正

`warned_keys` セットで「専用メッセージで既に警告したキー」を記録し、汎用チェックから除外。
owner 警告は1件に統一。

## テスト

- `test_todo_owner_missing_anonymous_warns` に **owner 警告は1件のみ**（重複なし）のアサートを追加
- `bash tests/run_all_tests.sh --api-only` → **249 passed**

## 補足

PR#63 で追加した「実行検証ゲート」を実際に回して反映確認していた際に発見した、#60 の軽微なバグ。
機能影響はなく警告テキストの重複のみ。マージ後に Memory Service の再ビルドが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)