### PR TITLE
run_all_tests.sh: base image 事前 pull でビルドハングを回避

### DIFF
--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -112,6 +112,18 @@ fi
 
 # テスト用コンテナの起動（-p でプロジェクト名を分離し、通常運用コンテナに影響しない）
 echo -e "${YELLOW}テスト用 Memory Service コンテナを起動中 (ポート: ${TEST_PORT})...${NC}"
+
+# base image を事前 pull（ビルダー非依存の堅牢化）。
+# BuildKit は base image が未キャッシュのとき "load metadata" ステップで、
+# docker CLI/engine の世代差がある環境でハングすることがある。先にキャッシュを
+# 満たしておくことで回避する（DOCKER_BUILDKIT=0 は compose v2 で確実に効かないため
+# ビルダー非依存の pull を採用）。pull 失敗時はビルドに委ねる。
+grep -E '^FROM ' "$PROJECT_DIR/memory-service/Dockerfile" | awk '{print $2}' | while read -r base_image; do
+    [ -z "$base_image" ] && continue
+    echo -e "  Base image を事前取得中: ${base_image}"
+    docker pull "$base_image" >/dev/null 2>&1 || echo -e "${YELLOW}  (事前 pull 失敗/スキップ。ビルド時に取得を試みます)${NC}"
+done
+
 docker compose -p "$TEST_PROJECT_NAME" -f "$PROJECT_DIR/memory-service/docker-compose.test.yml" up -d --build 2>&1 | while read -r line; do
     echo "  $line"
 done


### PR DESCRIPTION
## 概要
`bash tests/run_all_tests.sh` の API テスト用コンテナビルドが `#3 [internal] load metadata for docker.io/library/python:3.11-slim` で**ハング**する問題の恒久対策。

## 根本原因（接地済み）
- **直接原因**: BuildKit（`docker compose build`）の base image メタデータ解決が、**base image 未キャッシュ時**にハングする。
- **底の原因**: docker CLI（Homebrew `docker` 23.0.2）が Docker Desktop エンジン（20.10.23）を叩く**世代差**が誘因。
- **無罪の確認**: `docker pull` は成功、`curl` でレジストリ到達可（auth 200／registry 401）。→ ネットワーク・レジストリは正常。BuildKit 固有の経路だけが stall。

**実証（before/after）**:
| 状態 | `load metadata` |
|------|------|
| base image 未キャッシュ | 30分超ハング |
| `docker pull` でキャッシュ後 | 即通過・build 成功 |

## 対策
compose build の前に **Dockerfile の `FROM` を pull** してキャッシュを満たす（ビルダー非依存）。
`DOCKER_BUILDKIT=0` は compose v2 で確実に効かないため不採用。pull 失敗時はビルドに委ねる（安全側）。

```bash
grep -E '^FROM ' memory-service/Dockerfile | awk '{print $2}' | while read -r base_image; do
    docker pull "$base_image" >/dev/null 2>&1 || echo "  (事前 pull 失敗/スキップ)"
done
```

## 検証
- `bash tests/run_all_tests.sh --api-only` → 「Base image を事前取得中: python:3.11-slim」→ **API 249 passed / すべて成功**。

## 補足（別問題）
本 PR とは無関係に、full-suite の **Hook Tests は環境依存でフレーク**（`on-session-start.sh` が「Update available」バナーを出すとサマリを表示しない設計 × ローカルが origin より後ろ）。これは別途対応要否を検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)