### PR TITLE
Hook テストの update-banner フレークを解消（ISAC_SKIP_UPDATE_CHECK）

### DIFF
--- a/.claude/hooks/on-session-start.sh
+++ b/.claude/hooks/on-session-start.sh
@@ -45,8 +45,11 @@ UPDATE_STATUS=""
 ISAC_SOURCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 ISAC_CACHE_FILE="${ISAC_GLOBAL_DIR}/.version_cache"
 
+# ISAC_SKIP_UPDATE_CHECK=1 で更新チェックを明示スキップ（更新バナー抑止・テストの決定化用）
 # -e: ファイルでもディレクトリでも存在すれば真（git worktree では .git はファイル）
-if [ -e "${ISAC_SOURCE_DIR}/.git" ] && [ -f "${ISAC_CACHE_FILE}" ]; then
+if [ "${ISAC_SKIP_UPDATE_CHECK:-}" = "1" ]; then
+    UPDATE_STATUS="up_to_date"
+elif [ -e "${ISAC_SOURCE_DIR}/.git" ] && [ -f "${ISAC_CACHE_FILE}" ]; then
     LOCAL_HEAD=$(git -C "${ISAC_SOURCE_DIR}" rev-parse --short HEAD 2>/dev/null || true)
     CACHED_REMOTE=$(cat "${ISAC_CACHE_FILE}" 2>/dev/null || true)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,10 @@ isac status --no-cache
 export ISAC_NO_CACHE=1
 ```
 
+**セッション開始バナーの抑止**: `on-session-start.sh` はローカルがリモートより後ろだと
+「ISAC: Update available」バナーを表示し、1行サマリーを隠す。`ISAC_SKIP_UPDATE_CHECK=1` で
+更新チェックをスキップしてサマリーを常に表示できる（テストの決定化・バナー抑止用）。
+
 **Claude Code CLI での動作**: ユーザーが Claude Code CLI 内で `isac status` と入力した場合、on-prompt フックが `isac status` bash コマンドを自動実行し、バージョン情報を含むフル出力をコンテキストに注入する。Claude はこの出力をそのまま表示すること。
 
 ## コーディング規約

--- a/tests/test_hooks.sh
+++ b/tests/test_hooks.sh
@@ -1029,6 +1029,10 @@ echo "----------------------------------------"
 echo "on-session-start.sh テスト"
 echo "----------------------------------------"
 
+# 更新チェックの環境依存フレークを排除する（ローカルが origin より後ろだと
+# "Update available" バナーが出てサマリが隠れ、プロジェクトID等のアサートが落ちるため）。
+export ISAC_SKIP_UPDATE_CHECK=1
+
 # テスト1: 正常時に1行サマリーを出力
 echo "project_id: test-session-start" > "$TEST_DIR/.isac.yaml"
 cd "$TEST_DIR"
@@ -1165,6 +1169,8 @@ else
 fi
 
 echo ""
+
+unset ISAC_SKIP_UPDATE_CHECK
 
 # ========================================
 # isac CLI のテスト


### PR DESCRIPTION
## 概要
`run_all_tests.sh` の **Hook Tests が環境依存でフレーク**する問題を解消する（A 案）。

## 原因
`on-session-start.sh` は「警告（Memory 未接続 / **Update available** / Project 未設定）が1つでもあると、1行サマリーを出さず警告のみ」表示する設計。**ローカルが origin より後ろ**（`UPDATE_STATUS=update_available`）だと `ISAC: Update available` バナーが出てサマリーが隠れ、`test_hooks.sh` の on-session-start 系6件（プロジェクトID/Memory 状態/日本語ID 等のアサート）が落ちる。＝更新チェックのキャッシュ状態に依存するフレーク。

## 修正（A 案）
- **`on-session-start.sh`**: `ISAC_SKIP_UPDATE_CHECK=1` で更新チェックを明示スキップ（`UPDATE_STATUS=up_to_date` 扱い）する early guard を追加。バナー抑止・テスト決定化の両用途。
- **`test_hooks.sh`**: on-session-start テストセクションで同 env を `export`（末尾で `unset`）し、更新チェック状態に依存せず決定的に検証。
- **`CLAUDE.md`**: env var を記載。

## 検証（接地）
- **直接**: version_cache を不一致にして `update_available` を強制 → `skip無し`＝バナー（サマリ隠れる）／`skip=1`＝サマリー復活（プロジェクトID含む）を確認。
- **end-to-end**: `bash tests/run_all_tests.sh --hooks-only` → 該当6件を含む **Hook Tests PASSED / すべて成功**。

## 補足
挙動変更は最小（env 未設定時は従来どおり）。プロダクトの「更新があればサマリーを隠す」挙動自体は維持（B 案は不採用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)