### PR TITLE
fix: --agents で args が JSON 文字列のまま届き議題が空になる不具合

### DIFF
--- a/.claude/workflows/isac-review-agents.js
+++ b/.claude/workflows/isac-review-agents.js
@@ -31,7 +31,11 @@ export const meta = {
 }
 
 // ---- args 正規化 ----
-const A = args || {}
+// tool 経由の args は JSON 文字列で届くことがあるため、文字列ならパースする
+let A = args || {}
+if (typeof A === 'string') {
+  try { A = JSON.parse(A) } catch (e) { A = {} }
+}
 const TOPIC = A.topic || '(議題未指定)'
 const CONTEXT = A.context || '(レビュー材料未指定)'
 const OPTIONS = Array.isArray(A.options) ? A.options.filter(Boolean) : []


### PR DESCRIPTION
## 概要
`/isac-review --agents`（Workflow `isac-review-agents`）を **named 起動**すると、tool 経由の `args` が**JSON 文字列**としてスクリプトに届く（`typeof args === "string"`）。production スクリプトは `const A = args || {}` でそのまま扱っていたため `A.topic`/`A.options` が `undefined` になり、**議題・選択肢が空のままレビューが走っていた**（レビュアーが議題不明のまま作業ツリーを誤レビューする）。

## 検出経緯
§8 の A/B 実測を実際に走らせたところ、②の結果が `topic:"(議題未指定)"` になっていて発覚。0エージェントのプローブで `typeof args === "string"` を確認（接地）。

## 修正
`args` が文字列なら `JSON.parse` するフォールバックを追加：
```js
let A = args || {}
if (typeof A === 'string') { try { A = JSON.parse(A) } catch (e) { A = {} } }
```

## 検証
- プローブで `topic`/`options`/`N` が正しく伝播（`typeof_after_parse: "object"`）することを確認。
- 修正後に本番議題（ページネーション offset vs cursor）で ② を再実行 → 議題一致・vote 正常・🔴/provenance 出力とも正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)